### PR TITLE
Remove duplicated properties from path-line

### DIFF
--- a/src/styles/apollo-bright-detailed.json
+++ b/src/styles/apollo-bright-detailed.json
@@ -675,8 +675,6 @@
                     2
                 ]
             },
-            "line-join": "round",
-            "line-cap": "round",
             "minzoom": 12
         },
         {

--- a/src/styles/apollo-bright.json
+++ b/src/styles/apollo-bright.json
@@ -662,8 +662,6 @@
                     2
                 ]
             },
-            "line-join": "round",
-            "line-cap": "round",
             "minzoom": 12
         },
         {

--- a/src/styles/toner.json
+++ b/src/styles/toner.json
@@ -343,8 +343,6 @@
                 },
                 "line-gap-width": 3
             },
-            "line-join": "round",
-            "line-cap": "round",
             "minzoom": 12
         },
         {

--- a/src/styles/zen.json
+++ b/src/styles/zen.json
@@ -591,8 +591,6 @@
                     2
                 ]
             },
-            "line-join": "round",
-            "line-cap": "round",
             "minzoom": 12
         },
         {


### PR DESCRIPTION
Remove duplicated properties from the path-line layer (also not located in the layers layout object).